### PR TITLE
Prioritize query term

### DIFF
--- a/search.js
+++ b/search.js
@@ -9,42 +9,26 @@ function search(){
 }
 
 function generateUrl(){
-  let apiKey = getURLSafeVal($("#password"));
-  //let searchText =  getURLSafeVal($("#textSearch"));
-  let searchText = $("#textSearch").val();
+  let year = $("#selectYear").val();
+  let startdate = generateDate(year,0,1);
+  let enddate = generateDate(year,11,31);
 
   let url = new URL('https://www.googleapis.com/youtube/v3/search?')
 
   let params = {
                 part: 'snippet',
                 maxResults: 25,
-                q: searchText,
+                publishedAfter: startdate,
+                publishedBefore: enddate,
+                q: $("#textSearch").val(),
                 type: 'video',
-                key: apiKey
+                key: $("#password").val()
             }
   url.search = new URLSearchParams(params).toString();
-  url.href = AppendDateToUrl(url.href)
   return url;
-}
-
-//work around cause i think (not super sure) the google api doesn't support url encoding on ':' character, dates with '%3A' returns limited search results
-function AppendDateToUrl(href){
-  let year = $("#selectYear").val();
-  let startdate = generateDate(year,0,1);
-  let enddate = generateDate(year,11,31);
-
-  href = href + "&publishedAfter=" + startdate
-              + "&publishedBefore=" + enddate;
-  
-  return href;
-}
-
-function getURLSafeVal(element){
-  return encodeURIComponent(element.val());
 }
 
 function generateDate(year, month, day){
   let date = new Date(year,month,day).toISOString();
-  //date = encodeURIComponent(date);
   return date;
 }

--- a/search.js
+++ b/search.js
@@ -2,48 +2,41 @@ function search(){
     $("#results_table").empty();
     let url = generateUrl();
 
-    let headers = {
-      'Accept' : 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
-      'Accept-Encoding' : 'gzip, deflate, br',
-      'Alt-Used' :	'youtube.googleapis.com'
-
-    }
-    let fetchHeaders = new Headers(headers);
-
-    const init = {
-      method: 'GET',
-      headers: fetchHeaders,
-      mode: 'cors',
-      cache: 'default'
-    };
-
-    fetch(url, init)
+    fetch(url)
     .then(response => response.json())
     .then(data =>displayData(data));
-
+    
 }
 
 function generateUrl(){
   let apiKey = getURLSafeVal($("#password"));
-  let searchText =  getURLSafeVal($("#textSearch"));
+  //let searchText =  getURLSafeVal($("#textSearch"));
+  let searchText = $("#textSearch").val();
 
-  let year = $("#selectYear").val();
-  let startdate = generateDate(year,0,1);
-  let enddate = generateDate(year,11,31);
-
-  let url = new URL('https://youtube.googleapis.com/youtube/v3/search?')
+  let url = new URL('https://www.googleapis.com/youtube/v3/search?')
 
   let params = {
                 part: 'snippet',
                 maxResults: 25,
-                publishedAfter: startdate,
-                publishedBefore: enddate,
                 q: searchText,
                 type: 'video',
                 key: apiKey
             }
   url.search = new URLSearchParams(params).toString();
+  url.href = AppendDateToUrl(url.href)
   return url;
+}
+
+//work around cause i think (not super sure) the google api doesn't support url encoding on ':' character, dates with '%3A' returns limited search results
+function AppendDateToUrl(href){
+  let year = $("#selectYear").val();
+  let startdate = generateDate(year,0,1);
+  let enddate = generateDate(year,11,31);
+
+  href = href + "&publishedAfter=" + startdate
+              + "&publishedBefore=" + enddate;
+  
+  return href;
 }
 
 function getURLSafeVal(element){

--- a/search.js
+++ b/search.js
@@ -2,7 +2,22 @@ function search(){
     $("#results_table").empty();
     let url = generateUrl();
 
-    fetch(url)
+    let headers = {
+      'Accept' : 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+      'Accept-Encoding' : 'gzip, deflate, br',
+      'Alt-Used' :	'youtube.googleapis.com'
+
+    }
+    let fetchHeaders = new Headers(headers);
+
+    const init = {
+      method: 'GET',
+      headers: fetchHeaders,
+      mode: 'cors',
+      cache: 'default'
+    };
+
+    fetch(url, init)
     .then(response => response.json())
     .then(data =>displayData(data));
 
@@ -16,16 +31,16 @@ function generateUrl(){
   let startdate = generateDate(year,0,1);
   let enddate = generateDate(year,11,31);
 
-  let url = new URL('https://www.googleapis.com/youtube/v3/search?')
+  let url = new URL('https://youtube.googleapis.com/youtube/v3/search?')
 
   let params = {
-                key: apiKey,
-                q: searchText,
+                part: 'snippet',
+                maxResults: 25,
                 publishedAfter: startdate,
                 publishedBefore: enddate,
+                q: searchText,
                 type: 'video',
-                maxResults: 25,
-                part: 'snippet'
+                key: apiKey
             }
   url.search = new URLSearchParams(params).toString();
   return url;


### PR DESCRIPTION
Bug fixed
search results were based on the wrong string. query term was being double encoded, once by generateurlsafeval() and then again by UrlSearchParams().
